### PR TITLE
Support endless shell pipe streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,20 @@ Multiple proto files from a producer with input messages piped
 
 ### Usage with Kafka consumers
 
-Because Proto bytes can contain newlines (`\n`) and often do, we need to use a different marker to delimit the end of a message byte-stream and the beginning of the next.
-Proton expects this separator to be on a new line, and expects `--END--` by default.
+Because Proto bytes can contain newlines (`\n`) and often do,
+we need to use a different marker to delimit the end of a message byte-stream and the beginning of the next.
+Proton expects an end of message marker, which is `--END--` by default.
 
-You can add separators with tool like Kafkacat, like so:
+You can add markers at the end of each messae with tools like [kafkacat](https://github.com/edenhill/kcat), like so:
 
 ```shell script
-kcat -b my-broker:9092 -t my-topic -f '%s\n--END--\n'
+kcat -b my-broker:9092 -t my-topic -f '%s--END--'
 ```
 
 You can consume messages and parse them with Proton by doing the following:
 
 ```shell script
-kcat -b my-broker:9092 -t my-topic -f '%s\n--END--\n' -o beginning | proton json -f ./my-schema.proto
+kcat -b my-broker:9092 -t my-topic -f '%s--END--' -o beginning | proton json -f ./my-schema.proto
 ```
 
 **Don't see messages?**
@@ -86,7 +87,7 @@ If you execute the above command, but you don't see messages until you stop the 
 You can do this with the `stdbuf` command.
 
 ```shell script
-stdbuf -o0 kcat -b my-broker:9092 -t my-topic -f '%s\n--END--\n' -o beginning | proton json -f ./my-schema.proto
+stdbuf -o0 kcat -b my-broker:9092 -t my-topic -f '%s--END--' -o beginning | proton json -f ./my-schema.proto
 ```
 
 If you don't have `stdbuf`, you can install it via `brew install coreutils`.

--- a/README.md
+++ b/README.md
@@ -25,16 +25,15 @@ Usage:
   proton json [flags]
 
 Flags:
-  -f, --file string             Proto file path or url
-  -h, --help                    help for json
-      --indent                  Indent output json
-  -l, --line-separator string   Line separator string in case of piping data
-                                Defaults to "--END--" if not provided
-  -p, --package string          Proto package
-                                Defaults to the package found in the Proton file if not specified
-  -t, --type string             Proto message type
-                                Defaults to the first message type in the Proton file if not specified
-
+  -m, --end-of-message-marker string   Marker for end of message used when piping data
+                                       Defaults to "--END--" if not provided
+  -f, --file string                    Proto file path or url
+  -h, --help                           help for json
+      --indent                         Indent output json
+  -p, --package string                 Proto package
+                                       Defaults to the package found in the Proton file if not specified
+  -t, --type string                    Proto message type
+                                       Defaults to the first message type in the Proton file if not specified
 ```
 
 ## Examples
@@ -66,7 +65,7 @@ Multiple proto files from a producer with input messages piped
 
 ### Usage with Kafka consumers
 
-Because Proto bytes can contain newlines (`\n`) and often do, we need to use a different line separator when consuming.
+Because Proto bytes can contain newlines (`\n`) and often do, we need to use a different marker to delimit the end of a message byte-stream and the beginning of the next.
 Proton expects this separator to be on a new line, and expects `--END--` by default.
 
 You can add separators with tool like Kafkacat, like so:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Usage:
 
 Flags:
   -m, --end-of-message-marker string   Marker for end of message used when piping data
-                                       Defaults to "--END--" if not provided
   -f, --file string                    Proto file path or url
   -h, --help                           help for json
       --indent                         Indent output json
@@ -60,14 +59,14 @@ cat testdata/out.bin | proton json -f ./testdata/addressbook.proto
 
 Multiple proto files from a producer with input messages piped
 ```shell script
-./testdata/producer.sh | proton json -f ./testdata/addressbook.proto
+./testdata/producer.sh '--END--' | proton json -f ./testdata/addressbook.proto -m '--END--'
 ```
 
 ### Usage with Kafka consumers
 
 Because Proto bytes can contain newlines (`\n`) and often do,
 we need to use a different marker to delimit the end of a message byte-stream and the beginning of the next.
-Proton expects an end of message marker, which is `--END--` by default.
+Proton expects an end of message marker, or will read to the end of the stream if not provided.
 
 You can add markers at the end of each messae with tools like [kafkacat](https://github.com/edenhill/kcat), like so:
 
@@ -78,7 +77,7 @@ kcat -b my-broker:9092 -t my-topic -f '%s--END--'
 You can consume messages and parse them with Proton by doing the following:
 
 ```shell script
-kcat -b my-broker:9092 -t my-topic -f '%s--END--' -o beginning | proton json -f ./my-schema.proto
+kcat -b my-broker:9092 -t my-topic -f '%s--END--' -o beginning | proton json -f ./my-schema.proto -m '--END--'
 ```
 
 **Don't see messages?**
@@ -87,7 +86,7 @@ If you execute the above command, but you don't see messages until you stop the 
 You can do this with the `stdbuf` command.
 
 ```shell script
-stdbuf -o0 kcat -b my-broker:9092 -t my-topic -f '%s--END--' -o beginning | proton json -f ./my-schema.proto
+stdbuf -o0 kcat -b my-broker:9092 -t my-topic -f '%s--END--' -o beginning | proton json -f ./my-schema.proto -m '--END--'
 ```
 
 If you don't have `stdbuf`, you can install it via `brew install coreutils`.

--- a/cmd/json.go
+++ b/cmd/json.go
@@ -38,12 +38,12 @@ var jsonCmd = &cobra.Command{
 		}
 
 		c := json.Converter{
-			Parser:        protoParser,
-			Filename:      fileName,
-			Package:       pkg,
-			MessageType:   messageType,
-			Indent:        indent,
-			LineSeparator: lineSeparator,
+			Parser:             protoParser,
+			Filename:           fileName,
+			Package:            pkg,
+			MessageType:        messageType,
+			Indent:             indent,
+			EndOfMessageMarker: endOfMessageMarker,
 		}
 
 		if isInputFromPipe() {
@@ -99,7 +99,7 @@ var indent bool
 var file string
 var pkg string
 var messageType string
-var lineSeparator string
+var endOfMessageMarker string
 
 func init() {
 	rootCmd.AddCommand(jsonCmd)
@@ -114,8 +114,8 @@ func init() {
 		"\nDefaults to the package found in the Proton file if not specified")
 	jsonCmd.Flags().StringVarP(&messageType, "type", "t", "", "Proto message type"+
 		"\nDefaults to the first message type in the Proton file if not specified")
-	jsonCmd.Flags().StringVarP(&lineSeparator, "line-separator", "l", "",
-		fmt.Sprintf("Line separator string in case of piping data\nDefaults to %q if not provided", json.DefaultLineSeparator))
+	jsonCmd.Flags().StringVarP(&endOfMessageMarker, "end-of-message-marker", "m", "",
+		fmt.Sprintf("Marker for end of message used when piping data\nDefaults to %q if not provided", json.DefaultEndOfMessageMarker))
 }
 
 func isInputFromPipe() bool {

--- a/cmd/json.go
+++ b/cmd/json.go
@@ -115,7 +115,7 @@ func init() {
 	jsonCmd.Flags().StringVarP(&messageType, "type", "t", "", "Proto message type"+
 		"\nDefaults to the first message type in the Proton file if not specified")
 	jsonCmd.Flags().StringVarP(&endOfMessageMarker, "end-of-message-marker", "m", "",
-		fmt.Sprintf("Marker for end of message used when piping data\nDefaults to %q if not provided", json.DefaultEndOfMessageMarker))
+		"Marker for end of message used when piping data")
 }
 
 func isInputFromPipe() bool {

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -51,6 +51,8 @@ func (c Converter) Convert(r io.Reader) ([]byte, error) {
 // It returns a result channel and error channel which both can return multiple messages (a result or error for each message)
 // Because proto messages often contain newlines, we can't rely on new lines for knowing when one message ends and the
 // next begins, so instead it looks for a line containing only a specified LineSeparator (defaults to DefaultLineSeparator).
+// Although unlikely, it is possible that the LineSeparator can be part of the proto binary message, in which case the
+// parsing of that message will fail. If this happens, use a more complex LineSeparator.
 func (c Converter) ConvertStream(r io.Reader) (resultCh chan []byte, errorCh chan error) {
 	resultCh = make(chan []byte)
 	errorCh = make(chan error)

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -11,9 +11,6 @@ import (
 	"github.com/jhump/protoreflect/dynamic"
 )
 
-// DefaultEndOfMessageMarker is the default marker that is used when converting streams, unless otherwise specified.
-const DefaultEndOfMessageMarker = "--END--"
-
 // ProtoParser defines the interface for parsing proto files dynamically.
 type ProtoParser interface {
 	ParseFiles(filenames ...string) ([]*desc.FileDescriptor, error)
@@ -56,9 +53,6 @@ func (c Converter) Convert(r io.Reader) ([]byte, error) {
 func (c Converter) ConvertStream(r io.Reader) (resultCh chan []byte, errorCh chan error) {
 	resultCh = make(chan []byte)
 	errorCh = make(chan error)
-	if c.EndOfMessageMarker == "" {
-		c.EndOfMessageMarker = DefaultEndOfMessageMarker
-	}
 
 	md, err := c.createProtoMessageDescriptor()
 	if err != nil {

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -11,8 +11,8 @@ import (
 	"github.com/jhump/protoreflect/dynamic"
 )
 
-// DefaultLineSeparator is the default line separator that is used when converting streams, unless otherwise specified.
-const DefaultLineSeparator = "--END--"
+// DefaultEndOfMessageMarker is the default marker that is used when converting streams, unless otherwise specified.
+const DefaultEndOfMessageMarker = "--END--"
 
 // ProtoParser defines the interface for parsing proto files dynamically.
 type ProtoParser interface {
@@ -25,7 +25,7 @@ type Converter struct {
 	Filename             string
 	Package, MessageType string
 	Indent               bool
-	LineSeparator        string
+	EndOfMessageMarker   string
 }
 
 // Convert converts proto message to json.
@@ -50,14 +50,14 @@ func (c Converter) Convert(r io.Reader) ([]byte, error) {
 // ConvertStream converts multiple proto messages to json.
 // It returns a result channel and error channel which both can return multiple messages (a result or error for each message)
 // Because proto messages often contain newlines, we can't rely on new lines for knowing when one message ends and the
-// next begins, so instead it looks for a line containing only a specified LineSeparator (defaults to DefaultLineSeparator).
-// Although unlikely, it is possible that the LineSeparator can be part of the proto binary message, in which case the
-// parsing of that message will fail. If this happens, use a more complex LineSeparator.
+// next begins, so instead it looks for a line containing only a specified marker (defaults to DefaultEndOfMessageMarker).
+// Although unlikely, it is possible that the EndOfMessageMarker can be part of the proto binary message, in which case the
+// parsing of that message will fail. If this happens, use a more complex EndOfMessageMarker.
 func (c Converter) ConvertStream(r io.Reader) (resultCh chan []byte, errorCh chan error) {
 	resultCh = make(chan []byte)
 	errorCh = make(chan error)
-	if c.LineSeparator == "" {
-		c.LineSeparator = DefaultLineSeparator
+	if c.EndOfMessageMarker == "" {
+		c.EndOfMessageMarker = DefaultEndOfMessageMarker
 	}
 
 	md, err := c.createProtoMessageDescriptor()
@@ -79,9 +79,9 @@ func (c Converter) ConvertStream(r io.Reader) (resultCh chan []byte, errorCh cha
 			if err != nil {
 				break
 			}
-			// If the line is equal to c.LineSeparator (and a newline as reader.ReadBytes does not strip that), we know
-			// the message is finished, so we can start processing it.
-			if bytes.Equal(line, []byte(c.LineSeparator+"\n")) {
+			// If the line is equal to c.EndOfMessageMarker (and a newline as reader.ReadBytes does not strip that),
+			// we know the message is finished, so we can start processing it.
+			if bytes.Equal(line, []byte(c.EndOfMessageMarker+"\n")) {
 				parsed, err := c.unmarshalProtoBytesToJson(md, stripTrailingNewline(buf.Bytes()))
 				if err != nil {
 					errorCh <- err

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -77,6 +77,9 @@ func (c Converter) ConvertStream(r io.Reader) (resultCh chan []byte, errorCh cha
 			// Go over the stream line by line, as streams like Kafka send messages on next lines
 			line, err := reader.ReadBytes('\n')
 			if err != nil {
+				if err != io.EOF {
+					errorCh <- err
+				}
 				break
 			}
 			// If the line is equal to c.EndOfMessageMarker (and a newline as reader.ReadBytes does not strip that),

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -93,11 +93,14 @@ func (c Converter) ConvertStream(r io.Reader) (resultCh chan []byte, errorCh cha
 		}
 
 		// Process whatever is remaining on the read buffer
-		parsed, err := c.unmarshalProtoBytesToJson(md, stripTrailingNewline(buf.Bytes()))
-		if err != nil {
-			errorCh <- err
-		} else {
-			resultCh <- parsed
+		b := stripTrailingNewline(buf.Bytes())
+		if len(b) > 0 {
+			parsed, err := c.unmarshalProtoBytesToJson(md, b)
+			if err != nil {
+				errorCh <- err
+			} else {
+				resultCh <- parsed
+			}
 		}
 		close(resultCh)
 		close(errorCh)

--- a/internal/json/json_test.go
+++ b/internal/json/json_test.go
@@ -180,11 +180,11 @@ func Test_ConvertStream(t *testing.T) {
 	assert.NoError(t, err)
 
 	var b bytes.Buffer
-	b.WriteString(string(protoBytes) + "\n")
-	b.WriteString(DefaultEndOfMessageMarker + "\n")
-	b.WriteString(string(protoBytes) + "\n")
-	b.WriteString(DefaultEndOfMessageMarker + "\n")
-	b.WriteString(string(protoBytes) + "\n")
+	b.WriteString(string(protoBytes))
+	b.WriteString(DefaultEndOfMessageMarker)
+	b.WriteString(string(protoBytes))
+	b.WriteString(DefaultEndOfMessageMarker)
+	b.WriteString(string(protoBytes))
 
 	parser, filename, err := protoparser.NewFile("../../testdata/addressbook.proto")
 	assert.NoError(t, err)

--- a/internal/json/json_test.go
+++ b/internal/json/json_test.go
@@ -2,9 +2,7 @@ package json
 
 import (
 	"bytes"
-	"fmt"
 	"io"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -183,9 +181,9 @@ func Test_ConvertStream(t *testing.T) {
 
 	var b bytes.Buffer
 	b.WriteString(string(protoBytes) + "\n")
-	b.WriteString(DefaultLineSeparator + "\n")
+	b.WriteString(DefaultEndOfMessageMarker + "\n")
 	b.WriteString(string(protoBytes) + "\n")
-	b.WriteString(DefaultLineSeparator + "\n")
+	b.WriteString(DefaultEndOfMessageMarker + "\n")
 	b.WriteString(string(protoBytes) + "\n")
 
 	parser, filename, err := protoparser.NewFile("../../testdata/addressbook.proto")
@@ -213,7 +211,6 @@ func Test_ConvertStream(t *testing.T) {
 				done = true
 				break
 			}
-			_, _ = fmt.Fprintln(os.Stderr, e)
 			errors = append(errors, e)
 		}
 		if done {

--- a/internal/json/json_test.go
+++ b/internal/json/json_test.go
@@ -15,35 +15,7 @@ import (
 )
 
 func Test_Converter(t *testing.T) {
-	loc, _ := time.LoadLocation("UTC")
-	d := time.Date(2013, 1, 2, 9, 22, 0, 0, loc)
-	d2 := d.Add(27 * 24 * time.Hour).Add(23 * time.Minute)
-
-	addressBook := &another_tutorial.AddressBook{
-		People: []*another_tutorial.Person{{
-			Name:  "ABC",
-			Id:    1,
-			Email: "abc@thebeat.co",
-			Phones: []*another_tutorial.Person_PhoneNumber{{
-				Number: "123456",
-				Type:   another_tutorial.Person_HOME,
-			}},
-			LastUpdated: &timestamp.Timestamp{
-				Seconds: d.Unix(),
-			},
-		}, {
-			Name:  "DEF",
-			Id:    2,
-			Email: "def@thebeat.co",
-			Phones: []*another_tutorial.Person_PhoneNumber{{
-				Number: "789012",
-				Type:   another_tutorial.Person_HOME,
-			}},
-			LastUpdated: &timestamp.Timestamp{
-				Seconds: d2.Unix(),
-			},
-		}},
-	}
+	addressBook := genAddressBook()
 
 	tests := []struct {
 		name      string
@@ -198,5 +170,37 @@ func Test_Converter(t *testing.T) {
 			b, err := c.Convert(test.message())
 			test.assert(b, err)
 		})
+	}
+}
+
+func genAddressBook() *another_tutorial.AddressBook {
+	loc, _ := time.LoadLocation("UTC")
+	d := time.Date(2013, 1, 2, 9, 22, 0, 0, loc)
+	d2 := d.Add(27 * 24 * time.Hour).Add(23 * time.Minute)
+
+	return &another_tutorial.AddressBook{
+		People: []*another_tutorial.Person{{
+			Name:  "ABC",
+			Id:    1,
+			Email: "abc@thebeat.co",
+			Phones: []*another_tutorial.Person_PhoneNumber{{
+				Number: "123456",
+				Type:   another_tutorial.Person_HOME,
+			}},
+			LastUpdated: &timestamp.Timestamp{
+				Seconds: d.Unix(),
+			},
+		}, {
+			Name:  "DEF",
+			Id:    2,
+			Email: "def@thebeat.co",
+			Phones: []*another_tutorial.Person_PhoneNumber{{
+				Number: "789012",
+				Type:   another_tutorial.Person_HOME,
+			}},
+			LastUpdated: &timestamp.Timestamp{
+				Seconds: d2.Unix(),
+			},
+		}},
 	}
 }

--- a/testdata/producer.sh
+++ b/testdata/producer.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+bytes=`cat $PWD/testdata/out.bin`
+
+echo "$bytes"
+echo "--END--"
+sleep 1
+
+echo "$bytes"
+echo "--END--"
+sleep 1
+
+echo "$bytes"
+echo "--END--"
+sleep 1
+
+echo "$bytes"
+echo "--END--"

--- a/testdata/producer.sh
+++ b/testdata/producer.sh
@@ -2,17 +2,16 @@
 
 bytes=`cat $PWD/testdata/out.bin`
 
-echo "$bytes"
-echo "--END--"
+echo -n "$bytes"
+echo -n "--END--"
 sleep 1
 
-echo "$bytes"
-echo "--END--"
+echo -n "$bytes"
+echo -n "--END--"
 sleep 1
 
-echo "$bytes"
-echo "--END--"
+echo -n "$bytes"
+echo -n "--END--"
 sleep 1
 
-echo "$bytes"
-echo "--END--"
+echo -n "$bytes"

--- a/testdata/producer.sh
+++ b/testdata/producer.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
+arg=$1
+
 bytes=`cat $PWD/testdata/out.bin`
 
 echo -n "$bytes"
-echo -n "--END--"
+echo -n "${arg}"
 sleep 1
 
 echo -n "$bytes"
-echo -n "--END--"
+echo -n "${arg}"
 sleep 1
 
 echo -n "$bytes"
-echo -n "--END--"
+echo -n "${arg}"
 sleep 1
 
 echo -n "$bytes"


### PR DESCRIPTION
Proton did not work with streams of multiple messages, this PR changes the behaviour of reading from unix pipes.

Because Protobuf messages can (and often do) contain newline characters, we can't rely on `\n` for knowing if a message is over. Instead we need a different line separator. With this change, Proton uses an optional marker, and will print successful parses to STDOUT, and unsuccessful parses to STDERR.

By using a marker you will get a stream of messages, successful parses to stdout, unsuccessful to stderr. 

Proton will not stop on unsuccessful messages, example:


```bash
kcat -b my-broker:9092 -t my-topic -f '%s--END--' -o beginning | proton json -f ./my-schema.proto -m '--END--'
```


```bash
{ ... result 1 ...}    # stdout
{ ... result 2 ...}    # stdout
some parse error        # stderr
{ ... result 4 ...}    # stdout
{ ... result 5 ...}    # stdout
Unexpected EOF          # stderr
{ ... result 7 ...}    # stdout
```

The Readme contains a couple of examples on how to use this with a fake producer, as well as example code for using Kafkacat.