### PR TITLE
Also release when Bumpr creates a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - "*"
+  create:
+    tags:
+      - "*"
 
 jobs:
 


### PR DESCRIPTION
Docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#create

Problem: when Bumpr creates a tag, it is not "pushed", so the release action doesn't trigger.