### PR TITLE
Undo create-tag trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ on:
   push:
     tags:
       - "*"
-  create:
-    tags:
-      - "*"
 
 jobs:
 


### PR DESCRIPTION
Undoes this PR: https://github.com/beatlabs/proton/pull/6

As it seems to trigger twice