### PR TITLE
Change go get to go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Execute:
 
 ```bash
-$ go get github.com/beatlabs/proton
+$ go install github.com/beatlabs/proton/v2@latest
 ```
 Or download from [Releases](https://github.com/beatlabs/proton/releases)
 


### PR DESCRIPTION
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.